### PR TITLE
Change root node to body

### DIFF
--- a/app/js/controllers/main.js
+++ b/app/js/controllers/main.js
@@ -16,7 +16,7 @@ export default class MainController extends Controller {
   }
 
   onContextMenu() {
-    this.view.customizer.setRootNode(document.getElementById('root'));
+    this.view.customizer.setRootNode(document.body);
     this.attachView();
   }
 }


### PR DESCRIPTION
@justindarc @DouglasSherk - For this addon to work as an injectable addon I don't think we can expect that any node with a "root" id exists. I think we need to change this to body, but this breaks the test index.html inspector for some reason.
