### PR TITLE
Bug 1135842: use a two-finger swipe to open and close the customizer

### DIFF
--- a/app/js/controllers/main.js
+++ b/app/js/controllers/main.js
@@ -1,19 +1,49 @@
-/* global Controller */
+/* global Controller, Gesture */
 
 const ADDON_FILENAME = 'addon-temp.zip';
 
 export default class MainController extends Controller {
   constructor(options) {
     super(options);
-
     this.attached = false;
+    this.waitToBeOpened();
+  }
 
-    window.addEventListener('contextmenu', (evt) => {
-      if (this.attached) {
-        this.removeView();
-      } else {
-        this.attachView();
-      }
+  waitToBeOpened() {
+    var openGesture = {
+      type: 'swipe',    // Swipe:
+      numFingers: 1,    // with one finger,
+      startRegion: {    // from bottom 10% of the screen,
+        x0: 0, y0: 0.9, x1: 1, y1: 1
+      },
+      endRegion: {      // up into the top 80% of the screen,
+        x0: 0, y0: 0, x1: 1, y1: 0.80
+      },
+      maxTime: 1000,    // in less than 1 second.
+    };
+
+    Gesture.detect(openGesture).then(() => {
+      this.attachView();
+      this.waitToBeClosed();
+    });
+  }
+
+  waitToBeClosed() {
+    var closeGesture = {
+      type: 'swipe',    // Swipe:
+      numFingers: 1,    // with one finger,
+      startRegion: {    // from the middle of the screen
+        x0: 0, y0: 0.4, x1: 1, y1: 0.6
+      },
+      endRegion: {      // down into the bottom quarter of the screen
+        x0: 0, y0: 0.65, x1: 1, y1: 1.0
+      },
+      maxTime: 1000,    // in less than 1 second.
+    };
+
+    Gesture.detect(closeGesture).then(() => {
+      this.removeView();
+      this.waitToBeOpened();
     });
   }
 

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "gaia-sub-header": "gaia-components/gaia-sub-header",
     "gaia-list": "gaia-components/gaia-list",
     "gaia-button": "gaia-components/gaia-button",
-    "gaia-switch": "gaia-components/gaia-switch"
+    "gaia-switch": "gaia-components/gaia-switch",
+    "gesture": "fxos/gesture"
   },
   "resolutions": {
     "gaia-icons": "~0.7.4",

--- a/custombuild
+++ b/custombuild
@@ -19,6 +19,7 @@ const DIST_APP_ROOT = './dist/app/';
 
 var components = gulp.src([
   APP_ROOT + 'components/drag/drag.js',
+  APP_ROOT + 'components/gesture/gesture.js',
   APP_ROOT + 'components/gaia-component/gaia-component.js',
   APP_ROOT + 'components/gaia-dialog/gaia-dialog.js',
   APP_ROOT + 'components/gaia-dialog/gaia-dialog-prompt.js',


### PR DESCRIPTION
This is the new gesture code. Two finger swipe up from the bottom to open. And a two finger swipe down from the middle of the screen to close.

The gesture detector is in a new fxos/gesture repo, so this is a small patch.  Before I land it I want someone to make sure that I've done the right stuff with bower.json. I don't want to land something that only works on my computer.

@justindarc @DouglasSherk 
